### PR TITLE
Use scoped Manager binding to avoid cross-request state in Octane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup PHP environment
         uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
       - name: Install dependencies
         run: composer install
       - name: PHPCSFixer check
@@ -20,7 +22,7 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php_version: [8.1, 8.2]
+        php_version: ['8.2', '8.3', '8.4', '8.5']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
   },
   "require-dev": {
     "mockery/mockery": "^1.2",
-    "phpunit/phpunit": "^10.0",
-    "orchestra/testbench": "^8.0",
+    "phpunit/phpunit": "^11.5",
+    "orchestra/testbench": "^10.0",
     "jetbrains/phpstorm-attributes": "^1.0",
     "brainmaestro/composer-git-hooks": "dev-master",
     "laravel/pint": "^1.5"

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     }
   ],
   "require": {
+    "php": ">=8.2 <8.6",
     "laravel/framework": "^12.0",
     "tencentcloud/tencentcloud-sdk-php": "^3.0"
   },

--- a/config/federation-token.php
+++ b/config/federation-token.php
@@ -46,14 +46,14 @@ return [
         //            "statements" => [
         //                [
         //                    "action" => [
-                                    // 'cos:ListParts',
-                                    // 'cos:PutObject',
-                                    // 'cos:PostObject',
-                                    // 'cos:InitiateMultipartUpload',
-                                    // 'cos:UploadPart',
-                                    // 'cos:CompleteMultipartUpload',
-                                    // 'cos:AbortMultipartUpload',
-                                    // 'cos:ListMultipartUploads',
+        // 'cos:ListParts',
+        // 'cos:PutObject',
+        // 'cos:PostObject',
+        // 'cos:InitiateMultipartUpload',
+        // 'cos:UploadPart',
+        // 'cos:CompleteMultipartUpload',
+        // 'cos:AbortMultipartUpload',
+        // 'cos:ListMultipartUploads',
         //                    ],
         //                    "resource" => [
         //                        "qcs::cos:ap-beijing:uid/{uid}:{bucket}-{appid}/{date}/{uuid}/*",

--- a/src/QcloudFederationTokenServiceProvider.php
+++ b/src/QcloudFederationTokenServiceProvider.php
@@ -20,7 +20,7 @@ class QcloudFederationTokenServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->app->singleton(Manager::class, function () {
+        $this->app->scoped(Manager::class, function () {
             return new Manager(config('federation-token'));
         });
     }

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -9,7 +9,7 @@ use function config;
 
 class FeatureTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests;
+
+use Overtrue\LaravelQcloudFederationToken\Manager;
+
+class ServiceProviderTest extends TestCase
+{
+    public function test_manager_is_scoped_in_the_container(): void
+    {
+        $first = $this->app->make(Manager::class);
+        $second = $this->app->make(Manager::class);
+
+        $this->assertSame($first, $second);
+
+        $this->app->forgetScopedInstances();
+
+        $third = $this->app->make(Manager::class);
+
+        $this->assertNotSame($first, $third);
+    }
+}


### PR DESCRIPTION
## Summary
- change `Manager` container registration from `singleton` to `scoped`
- keep one `Manager` per request / job lifecycle while avoiding cross-request state reuse
- add `ServiceProviderTest` to verify scoped lifecycle behavior

## Why
`singleton` can retain runtime-mutated config/state across requests in long-lived workers (e.g. Octane).
`scoped` is lifecycle-safe for Octane and queue workers while preserving per-request reuse.

## Tests
- added `Tests\\ServiceProviderTest::test_manager_is_scoped_in_the_container`
